### PR TITLE
Add Support for knative tvos Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The following targets are currently supported:
 - iosSimulatorArm64
 - macosX64
 - macosArm64
+- tvosArm64
+- tvosSimulatorArm64
+- tvosX64
 
 ## Download
 

--- a/cache4k/build.gradle.kts
+++ b/cache4k/build.gradle.kts
@@ -33,6 +33,9 @@ kotlin {
     iosSimulatorArm64()
     macosX64()
     macosArm64()
+    tvosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
 
     sourceSets {
         all {


### PR DESCRIPTION
This PR adds support for the following additional tvos platforms:
- tvosArm64
- tvosSimulatorArm64
- tvosX64

It'd be great if you could merge this and push a release to unblock me.