### PR TITLE
Enable default target hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ The following targets are currently supported:
 - iosSimulatorArm64
 - macosX64
 - macosArm64
+- tvosX64
 - tvosArm64
 - tvosSimulatorArm64
-- tvosX64
+- watchosX64
 - watchosArm64
 - watchosSimulatorArm64
-- watchosX64
 - linuxX64
 - mingwX64
 

--- a/cache4k/build.gradle.kts
+++ b/cache4k/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.vanniktech.maven.publish.SonatypeHost
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JsModuleKind
 
 plugins {
@@ -17,6 +18,30 @@ mavenPublishing {
 
 kotlin {
     explicitApi()
+
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    targetHierarchy.default {
+        group("jvmAndIos") {
+            withJvm()
+            withIosX64()
+            withIosArm64()
+            withIosSimulatorArm64()
+        }
+        group("unixDesktop") {
+            withLinuxX64()
+            withMacosX64()
+            withMacosArm64()
+        }
+        group("nonIosApple") {
+            withTvosX64()
+            withTvosArm64()
+            withTvosSimulatorArm64()
+            withWatchosX64()
+            withWatchosArm64()
+            withWatchosSimulatorArm64()
+        }
+    }
+
     jvm {
         compilations.all {
             compilerOptions.configure {
@@ -44,12 +69,12 @@ kotlin {
     iosSimulatorArm64()
     macosX64()
     macosArm64()
+    tvosX64()
     tvosArm64()
     tvosSimulatorArm64()
-    tvosX64()
+    watchosX64()
     watchosArm64()
     watchosSimulatorArm64()
-    watchosX64()
     linuxX64()
     mingwX64()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ kotlinBinaryCompabilityValidator = "0.13.0"
 mavenPublish = "0.25.2"
 atomicfu = "0.20.2"
 statelyIso = "1.2.5"
+toolchainsResolver = "0.4.0"
 
 [libraries]
 plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,19 @@
 [versions]
-detekt = "1.22.0"
-dokka = "1.8.10"
-coroutines = "1.6.4"
 kotlin = "1.8.20"
+dokka = "1.8.10"
 kotlinBinaryCompabilityValidator = "0.13.0"
+toolchainsResolver = "0.4.0"
+detekt = "1.22.0"
 mavenPublish = "0.25.2"
+coroutines = "1.6.4"
 atomicfu = "0.20.2"
 statelyIso = "1.2.5"
-toolchainsResolver = "0.4.0"
 
 [libraries]
-plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
-plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 plugin-kotlinBinaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "kotlinBinaryCompabilityValidator" }
+plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 plugin-mavenPublish = { module ="com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,8 +21,19 @@ pluginManagement {
             }
         }
     }
+
+    val toolchainsResolverVersion = file("$rootDir/gradle/libs.versions.toml")
+        .readLines()
+        .first { it.contains("toolchainsResolver") }
+        .substringAfter("=")
+        .trim()
+        .removeSurrounding("\"")
+
+    plugins {
+        id("org.gradle.toolchains.foojay-resolver-convention") version toolchainsResolverVersion
+    }
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+    id("org.gradle.toolchains.foojay-resolver-convention")
 }


### PR DESCRIPTION
Enable new [default hierarchy API](https://kotlinlang.org/docs/multiplatform-hierarchy.html#default-hierarchy). Added target groups:
- `jvmAndIos`
- `unixDestop`
- `nonIosApple`

to prepare for `androidx.collection` KMP exploration.