### PR TITLE
Use AndroidX Collection KMP for JVM and iOS, macOS, and linux targets

### DIFF
--- a/cache4k/build.gradle.kts
+++ b/cache4k/build.gradle.kts
@@ -13,12 +13,19 @@ kotlin {
         }
         val jvmAndIosMain by getting {
             dependencies {
+                dependsOn(commonMain)
                 implementation(libs.androidx.collection)
             }
         }
         val unixDesktopMain by getting {
             dependencies {
+                dependsOn(commonMain)
                 implementation(libs.androidx.collection)
+            }
+        }
+        val nonIosAppleMain by getting {
+            dependencies {
+                dependsOn(commonMain)
             }
         }
         val commonTest by getting {

--- a/cache4k/build.gradle.kts
+++ b/cache4k/build.gradle.kts
@@ -11,6 +11,16 @@ kotlin {
                 implementation(libs.atomicfu)
             }
         }
+        val jvmAndIosMain by getting {
+            dependencies {
+                implementation(libs.androidx.collection)
+            }
+        }
+        val unixDesktopMain by getting {
+            dependencies {
+                implementation(libs.androidx.collection)
+            }
+        }
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))

--- a/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -1,0 +1,10 @@
+package io.github.reactivecircus.cache4k
+
+internal expect class ConcurrentMutableMap<Key : Any, Value : Any>() {
+    val size: Int
+    val values: Collection<Value>
+    operator fun get(key: Key): Value?
+    fun put(key: Key, value: Value): Value?
+    fun remove(key: Key): Value?
+    fun clear()
+}

--- a/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/KeyedSynchronizer.kt
+++ b/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/KeyedSynchronizer.kt
@@ -1,6 +1,5 @@
 package io.github.reactivecircus.cache4k
 
-import co.touchlab.stately.collections.IsoMutableMap
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.sync.Mutex
@@ -11,7 +10,7 @@ import kotlinx.coroutines.sync.withLock
  */
 internal class KeyedSynchronizer<Key : Any> {
 
-    private val keyBasedMutexes = IsoMutableMap<Key, MutexEntry>()
+    private val keyBasedMutexes = ConcurrentMutableMap<Key, MutexEntry>()
 
     private val mapLock = reentrantLock()
 
@@ -40,7 +39,7 @@ internal class KeyedSynchronizer<Key : Any> {
             mutexEntry.counter++
             // save the lock entry to the map if it has just been created
             if (keyBasedMutexes[key] == null) {
-                keyBasedMutexes[key] = mutexEntry
+                keyBasedMutexes.put(key, mutexEntry)
             }
 
             return mutexEntry.mutex

--- a/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/RealCache.kt
+++ b/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/RealCache.kt
@@ -1,6 +1,5 @@
 package io.github.reactivecircus.cache4k
 
-import co.touchlab.stately.collections.IsoMutableMap
 import co.touchlab.stately.collections.IsoMutableSet
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
@@ -38,7 +37,7 @@ internal class RealCache<Key : Any, Value : Any>(
     private val eventListener: CacheEventListener<Key, Value>?,
 ) : Cache<Key, Value> {
 
-    private val cacheEntries = IsoMutableMap<Key, CacheEntry<Key, Value>>()
+    private val cacheEntries = ConcurrentMutableMap<Key, CacheEntry<Key, Value>>()
 
     /**
      * Whether to perform size based evictions.
@@ -138,7 +137,7 @@ internal class RealCache<Key : Any, Value : Any>(
                 writeTimeMark = atomic(nowTimeMark),
             )
             recordWrite(newEntry)
-            cacheEntries[key] = newEntry
+            cacheEntries.put(key, newEntry)
         }
         onEvent(
             oldValue?.let {

--- a/cache4k/src/jsMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/jsMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -1,0 +1,29 @@
+package io.github.reactivecircus.cache4k
+
+import co.touchlab.stately.collections.IsoMutableMap
+
+internal actual class ConcurrentMutableMap<Key : Any, Value : Any> {
+    private val map = IsoMutableMap<Key, Value>()
+
+    actual val size: Int
+        get() = map.size
+
+    actual val values: Collection<Value>
+        get() = map.values
+
+    actual operator fun get(key: Key): Value? {
+        return map[key]
+    }
+
+    actual fun put(key: Key, value: Value): Value? {
+        return map.put(key, value)
+    }
+
+    actual fun remove(key: Key): Value? {
+        return map.remove(key)
+    }
+
+    actual fun clear() {
+        map.clear()
+    }
+}

--- a/cache4k/src/jvmAndIosMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/jvmAndIosMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -1,0 +1,35 @@
+package io.github.reactivecircus.cache4k
+
+import androidx.collection.SimpleArrayMap
+
+internal actual class ConcurrentMutableMap<Key : Any, Value : Any> {
+    private val map = SimpleArrayMap<Key, Value>()
+
+    actual val size: Int
+        get() = map.size()
+
+    actual val values: Collection<Value>
+        get() {
+            val values = mutableListOf<Value>()
+            for (i in 0 until map.size()) {
+                values.add(map.valueAt(i))
+            }
+            return values
+        }
+
+    actual operator fun get(key: Key): Value? {
+        return map[key]
+    }
+
+    actual fun put(key: Key, value: Value): Value? {
+        return map.put(key, value)
+    }
+
+    actual fun remove(key: Key): Value? {
+        return map.remove(key)
+    }
+
+    actual fun clear() {
+        map.clear()
+    }
+}

--- a/cache4k/src/mingwX64Main/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/mingwX64Main/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -1,0 +1,29 @@
+package io.github.reactivecircus.cache4k
+
+import co.touchlab.stately.collections.IsoMutableMap
+
+internal actual class ConcurrentMutableMap<Key : Any, Value : Any> {
+    private val map = IsoMutableMap<Key, Value>()
+
+    actual val size: Int
+        get() = map.size
+
+    actual val values: Collection<Value>
+        get() = map.values
+
+    actual operator fun get(key: Key): Value? {
+        return map[key]
+    }
+
+    actual fun put(key: Key, value: Value): Value? {
+        return map.put(key, value)
+    }
+
+    actual fun remove(key: Key): Value? {
+        return map.remove(key)
+    }
+
+    actual fun clear() {
+        map.clear()
+    }
+}

--- a/cache4k/src/nonIosAppleMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/nonIosAppleMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -1,0 +1,29 @@
+package io.github.reactivecircus.cache4k
+
+import co.touchlab.stately.collections.IsoMutableMap
+
+internal actual class ConcurrentMutableMap<Key : Any, Value : Any> {
+    private val map = IsoMutableMap<Key, Value>()
+
+    actual val size: Int
+        get() = map.size
+
+    actual val values: Collection<Value>
+        get() = map.values
+
+    actual operator fun get(key: Key): Value? {
+        return map[key]
+    }
+
+    actual fun put(key: Key, value: Value): Value? {
+        return map.put(key, value)
+    }
+
+    actual fun remove(key: Key): Value? {
+        return map.remove(key)
+    }
+
+    actual fun clear() {
+        map.clear()
+    }
+}

--- a/cache4k/src/unixDesktopMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/unixDesktopMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -1,0 +1,35 @@
+package io.github.reactivecircus.cache4k
+
+import androidx.collection.SimpleArrayMap
+
+internal actual class ConcurrentMutableMap<Key : Any, Value : Any> {
+    private val map = SimpleArrayMap<Key, Value>()
+
+    actual val size: Int
+        get() = map.size()
+
+    actual val values: Collection<Value>
+        get() {
+            val values = mutableListOf<Value>()
+            for (i in 0 until map.size()) {
+                values.add(map.valueAt(i))
+            }
+            return values
+        }
+
+    actual operator fun get(key: Key): Value? {
+        return map[key]
+    }
+
+    actual fun put(key: Key, value: Value): Value? {
+        return map.put(key, value)
+    }
+
+    actual fun remove(key: Key): Value? {
+        return map.remove(key)
+    }
+
+    actual fun clear() {
+        map.clear()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ mavenPublish = "0.25.2"
 coroutines = "1.6.4"
 atomicfu = "0.20.2"
 statelyIso = "1.2.5"
+androidx-collection = "1.3.0-alpha04"
 
 [libraries]
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -21,6 +22,7 @@ coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", ve
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 stately-isoCollections = { module = "co.touchlab:stately-iso-collections", version.ref = "statelyIso" }
+androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,11 @@ pluginManagement {
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
     repositories {
+        google {
+            content {
+                includeGroupByRegex("androidx.*")
+            }
+        }
         mavenCentral()
     }
 }


### PR DESCRIPTION
Replace stately's `IsoMutableMap` with `SimpleArrayMap` from `androidx.collection` for jvm, ios, macos, and linux targets.