### PR TITLE
Use `ConcurrentHashMap` for JVM target

### DIFF
--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -5,4 +5,3 @@ org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=warn
 
 kotlin.code.style=official
-kotlin.experimental.tryK2=true

--- a/build-logic/src/main/kotlin/io/github/reactivecircus/cache4k/buildlogic/convention/ConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/reactivecircus/cache4k/buildlogic/convention/ConventionPlugin.kt
@@ -183,22 +183,19 @@ private fun KotlinMultiplatformExtension.configureTargets(project: Project) {
     applyDefaultHierarchyTemplate()
 
     sourceSets {
-        val jvmAndIos by creating {
+        val nonJvmMain by creating {
             dependsOn(commonMain.get())
         }
-        iosMain.get().dependsOn(jvmAndIos)
-        jvmMain.get().dependsOn(jvmAndIos)
-
-        val nonJvm by creating {
-            dependsOn(commonMain.get())
+        val jvmLincheck by getting {
+            dependsOn(jvmMain.get())
         }
-        jsMain.get().dependsOn(nonJvm)
+        jsMain.get().dependsOn(nonJvmMain)
         @Suppress("UnusedPrivateProperty")
         val wasmJsMain by getting {
-            dependsOn(nonJvm)
+            dependsOn(nonJvmMain)
         }
-        appleMain.get().dependsOn(nonJvm)
-        linuxMain.get().dependsOn(nonJvm)
-        mingwMain.get().dependsOn(nonJvm)
+        appleMain.get().dependsOn(nonJvmMain)
+        linuxMain.get().dependsOn(nonJvmMain)
+        mingwMain.get().dependsOn(nonJvmMain)
     }
 }

--- a/build-logic/src/main/kotlin/io/github/reactivecircus/cache4k/buildlogic/convention/ConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/reactivecircus/cache4k/buildlogic/convention/ConventionPlugin.kt
@@ -182,6 +182,7 @@ private fun KotlinMultiplatformExtension.configureTargets(project: Project) {
     mingwX64()
     applyDefaultHierarchyTemplate()
 
+    @Suppress("UnusedPrivateProperty")
     sourceSets {
         val nonJvmMain by creating {
             dependsOn(commonMain.get())
@@ -190,7 +191,6 @@ private fun KotlinMultiplatformExtension.configureTargets(project: Project) {
             dependsOn(jvmMain.get())
         }
         jsMain.get().dependsOn(nonJvmMain)
-        @Suppress("UnusedPrivateProperty")
         val wasmJsMain by getting {
             dependsOn(nonJvmMain)
         }

--- a/cache4k/build.gradle.kts
+++ b/cache4k/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
         }
         jvmLincheck {
             dependencies {
-                dependsOn(jvmMain)
                 implementation(kotlin("test-junit5"))
                 implementation(libs.lincheck)
             }

--- a/cache4k/build.gradle.kts
+++ b/cache4k/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
         }
         jvmLincheck {
             dependencies {
+                dependsOn(jvmMain)
                 implementation(kotlin("test-junit5"))
                 implementation(libs.lincheck)
             }

--- a/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -1,0 +1,10 @@
+package io.github.reactivecircus.cache4k
+
+internal expect class ConcurrentMutableMap<Key : Any, Value : Any>() {
+    val size: Int
+    val values: Collection<Value>
+    operator fun get(key: Key): Value?
+    fun put(key: Key, value: Value): Value?
+    fun remove(key: Key): Value?
+    fun clear()
+}

--- a/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/KeyedSynchronizer.kt
+++ b/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/KeyedSynchronizer.kt
@@ -1,6 +1,5 @@
 package io.github.reactivecircus.cache4k
 
-import co.touchlab.stately.collections.IsoMutableMap
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.sync.Mutex
@@ -11,7 +10,7 @@ import kotlinx.coroutines.sync.withLock
  */
 internal class KeyedSynchronizer<Key : Any> {
 
-    private val keyBasedMutexes = IsoMutableMap<Key, MutexEntry>()
+    private val keyBasedMutexes = ConcurrentMutableMap<Key, MutexEntry>()
 
     private val mapLock = reentrantLock()
 
@@ -40,7 +39,7 @@ internal class KeyedSynchronizer<Key : Any> {
             mutexEntry.counter++
             // save the lock entry to the map if it has just been created
             if (keyBasedMutexes[key] == null) {
-                keyBasedMutexes[key] = mutexEntry
+                keyBasedMutexes.put(key, mutexEntry)
             }
 
             return mutexEntry.mutex

--- a/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/RealCache.kt
+++ b/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/RealCache.kt
@@ -1,6 +1,5 @@
 package io.github.reactivecircus.cache4k
 
-import co.touchlab.stately.collections.IsoMutableMap
 import co.touchlab.stately.collections.IsoMutableSet
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
@@ -38,7 +37,7 @@ internal class RealCache<Key : Any, Value : Any>(
     private val eventListener: CacheEventListener<Key, Value>?,
 ) : Cache<Key, Value> {
 
-    private val cacheEntries = IsoMutableMap<Key, CacheEntry<Key, Value>>()
+    private val cacheEntries = ConcurrentMutableMap<Key, CacheEntry<Key, Value>>()
 
     /**
      * Whether to perform size based evictions.
@@ -138,7 +137,7 @@ internal class RealCache<Key : Any, Value : Any>(
                 writeTimeMark = atomic(nowTimeMark),
             )
             recordWrite(newEntry)
-            cacheEntries[key] = newEntry
+            cacheEntries.put(key, newEntry)
         }
         onEvent(
             oldValue?.let {

--- a/cache4k/src/jvmMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/jvmMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -1,0 +1,29 @@
+package io.github.reactivecircus.cache4k
+
+import java.util.concurrent.ConcurrentHashMap
+
+internal actual class ConcurrentMutableMap<Key : Any, Value : Any> {
+    private val map = ConcurrentHashMap<Key, Value>()
+
+    actual val size: Int
+        get() = map.size
+
+    actual val values: Collection<Value>
+        get() = map.values
+
+    actual operator fun get(key: Key): Value? {
+        return map[key]
+    }
+
+    actual fun put(key: Key, value: Value): Value? {
+        return map.put(key, value)
+    }
+
+    actual fun remove(key: Key): Value? {
+        return map.remove(key)
+    }
+
+    actual fun clear() {
+        map.clear()
+    }
+}

--- a/cache4k/src/jvmMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/jvmMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -5,25 +5,15 @@ import java.util.concurrent.ConcurrentHashMap
 internal actual class ConcurrentMutableMap<Key : Any, Value : Any> {
     private val map = ConcurrentHashMap<Key, Value>()
 
-    actual val size: Int
-        get() = map.size
+    actual val size: Int get() = map.size
 
-    actual val values: Collection<Value>
-        get() = map.values
+    actual val values: Collection<Value> get() = map.values
 
-    actual operator fun get(key: Key): Value? {
-        return map[key]
-    }
+    actual operator fun get(key: Key): Value? = map[key]
 
-    actual fun put(key: Key, value: Value): Value? {
-        return map.put(key, value)
-    }
+    actual fun put(key: Key, value: Value): Value? = map.put(key, value)
 
-    actual fun remove(key: Key): Value? {
-        return map.remove(key)
-    }
+    actual fun remove(key: Key): Value? = map.remove(key)
 
-    actual fun clear() {
-        map.clear()
-    }
+    actual fun clear() = map.clear()
 }

--- a/cache4k/src/nonJvmMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/nonJvmMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -5,25 +5,15 @@ import co.touchlab.stately.collections.IsoMutableMap
 internal actual class ConcurrentMutableMap<Key : Any, Value : Any> {
     private val map = IsoMutableMap<Key, Value>()
 
-    actual val size: Int
-        get() = map.size
+    actual val size: Int get() = map.size
 
-    actual val values: Collection<Value>
-        get() = map.values
+    actual val values: Collection<Value> get() = map.values
 
-    actual operator fun get(key: Key): Value? {
-        return map[key]
-    }
+    actual operator fun get(key: Key): Value? = map[key]
 
-    actual fun put(key: Key, value: Value): Value? {
-        return map.put(key, value)
-    }
+    actual fun put(key: Key, value: Value): Value? = map.put(key, value)
 
-    actual fun remove(key: Key): Value? {
-        return map.remove(key)
-    }
+    actual fun remove(key: Key): Value? = map.remove(key)
 
-    actual fun clear() {
-        map.clear()
-    }
+    actual fun clear() = map.clear()
 }

--- a/cache4k/src/nonJvmMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
+++ b/cache4k/src/nonJvmMain/kotlin/io/github/reactivecircus/cache4k/ConcurrentMutableMap.kt
@@ -1,0 +1,29 @@
+package io.github.reactivecircus.cache4k
+
+import co.touchlab.stately.collections.IsoMutableMap
+
+internal actual class ConcurrentMutableMap<Key : Any, Value : Any> {
+    private val map = IsoMutableMap<Key, Value>()
+
+    actual val size: Int
+        get() = map.size
+
+    actual val values: Collection<Value>
+        get() = map.values
+
+    actual operator fun get(key: Key): Value? {
+        return map[key]
+    }
+
+    actual fun put(key: Key, value: Value): Value? {
+        return map.put(key, value)
+    }
+
+    actual fun remove(key: Key): Value? {
+        return map.remove(key)
+    }
+
+    actual fun clear() {
+        map.clear()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,3 @@ org.gradle.configureondemand=true
 org.gradle.caching=true
 
 kotlin.code.style=official
-kotlin.experimental.tryK2=false


### PR DESCRIPTION
https://github.com/ReactiveCircus/cache4k/pull/38 attempts to use AndroidX Collection KMP on JVM and iOS (and a few others) for the thread-safe mutable map implementation to address JVM performance issue with Stately.

However both our basic `JvmConcurrencyTest` and [lincheck](https://github.com/Kotlin/kotlinx-lincheck) surfaced `ConcurrentModificationException` in AndroidX Collection's `SimpleArrayMap`.

This PR instead use `ConcurrentHashMap` for JVM, and Stately for all other targets.

Our `JvmConturrencyTest` is passing but Lincheck's Model checking test still surfaces some linearizability issues with our `RealCache` implementation, though it's not a regression. https://github.com/ReactiveCircus/cache4k/issues/47