### PR TITLE
Implement dynamic cache entry expiration

### DIFF
--- a/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/Cache.kt
+++ b/cache4k/src/commonMain/kotlin/io/github/reactivecircus/cache4k/Cache.kt
@@ -1,6 +1,7 @@
 package io.github.reactivecircus.cache4k
 
 import kotlin.time.Duration
+import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
 /**
@@ -69,6 +70,12 @@ public interface Cache<in Key : Any, Value : Any> {
         public fun expireAfterAccess(duration: Duration): Builder<K, V>
 
         /**
+         * Specifies a function that takes the cache entry key and value, and returns a [TimeMark] at which
+         * time the entry should expire, or null if the entry does not have a set expiration time.
+         */
+        public fun expiresAt(expiresAt: (K, V) -> TimeMark?): Builder<K, V>
+
+        /**
          * Specifies the maximum number of entries the cache may contain.
          * Cache eviction policy is based on LRU - i.e. least recently accessed entries get evicted first.
          *
@@ -110,8 +117,8 @@ public interface Cache<in Key : Any, Value : Any> {
 internal class CacheBuilderImpl<K : Any, V : Any> : Cache.Builder<K, V> {
 
     private var expireAfterWriteDuration = Duration.INFINITE
-
     private var expireAfterAccessDuration = Duration.INFINITE
+    private var expiresAt: ((K, V) -> TimeMark?)? = null
     private var maxSize = UNSET_LONG
     private var timeSource: TimeSource? = null
     private var eventListener: CacheEventListener<K, V>? = null
@@ -128,6 +135,10 @@ internal class CacheBuilderImpl<K : Any, V : Any> : Cache.Builder<K, V> {
             "expireAfterAccess duration must be positive"
         }
         this.expireAfterAccessDuration = duration
+    }
+
+    override fun expiresAt(expiresAt: (K, V) -> TimeMark?): Cache.Builder<K, V> = apply {
+        this.expiresAt = expiresAt
     }
 
     override fun maximumCacheSize(size: Long): CacheBuilderImpl<K, V> = apply {
@@ -149,6 +160,7 @@ internal class CacheBuilderImpl<K : Any, V : Any> : Cache.Builder<K, V> {
         return RealCache(
             expireAfterWriteDuration,
             expireAfterAccessDuration,
+            expiresAt,
             maxSize,
             timeSource ?: TimeSource.Monotonic,
             eventListener,

--- a/cache4k/src/commonTest/kotlin/io/github/reactivecircus/cache4k/CacheExpiryTest.kt
+++ b/cache4k/src/commonTest/kotlin/io/github/reactivecircus/cache4k/CacheExpiryTest.kt
@@ -242,4 +242,42 @@ class CacheExpiryTest {
         assertEquals("cat", cache.get(2))
         assertEquals("bird", cache.get(3))
     }
+    
+    @Test
+    fun expiresAtEntryEvictedAfterExpirationTimeSet() {
+        val dog = "dog"
+
+        val cache = Cache.Builder<Long, String>()
+            .timeSource(fakeTimeSource)
+            .expiresAt { _, value -> fakeTimeSource.markNow() + value.length.minutes }
+            .build()
+
+        cache.put(1, dog)
+        assertEquals(dog, cache.get(1))
+
+        fakeTimeSource += 1.minutes
+        assertEquals(dog, cache.get(1))
+
+        fakeTimeSource += dog.length.minutes
+        assertNull(cache.get(1))
+    }
+
+    @Test
+    fun expiresAtEntryNoEvictionWhenNoExpirationTimeSet() {
+        val dog = "dog"
+
+        val cache = Cache.Builder<Long, String>()
+            .timeSource(fakeTimeSource)
+            .expiresAt { _, _ -> null }
+            .build()
+
+        cache.put(1, dog)
+        assertEquals(dog, cache.get(1))
+
+        fakeTimeSource += 1.minutes
+        assertEquals(dog, cache.get(1))
+
+        fakeTimeSource += dog.length.minutes
+        assertEquals(dog, cache.get(1))
+    }
 }


### PR DESCRIPTION
I've implemented the functionality to dynamically set a specific expiration time, when a cache entry is created. At mentioned in issue #18 this feature can be very useful in some scenarios, when you know some value expires at a specific time.

I've currently only implemented the ability to set an expiration time when an entry is created, as that seemed to be the most common and useful case, but perhaps being able to update the expiration time could be useful as well.


There is currently a bug in the implementation, that the entry is not actually evicted from the cache, but just returns a null value, when retrieving the cache because it is expired. I could add a third queue, that tracks entries with a set expiration, but figured it was easier to discuss the options first.